### PR TITLE
Fix ToolShortcuts on latest game version

### DIFF
--- a/KeyBindings.cs
+++ b/KeyBindings.cs
@@ -6,7 +6,7 @@ using UnityEngine.InputSystem.Controls;
 
 namespace ToolShortcuts
 {
-    public class KeyBindings : IInitializableSingleton
+    public class KeyBindings : ILoadableSingleton
     {
         public Dictionary<ToolGroupName, KeyControl> GroupTools;
 
@@ -17,7 +17,7 @@ namespace ToolShortcuts
             Plugin.KeyBindings = this;
         }
 
-        public void Initialize()
+        public void Load()
         {
             GroupTools = new Dictionary<ToolGroupName, KeyControl> {
                 { ToolGroupName.TreeCutting, ConfigEntryToKeyControl(KeyBindingsConfig.treeCuttingGroupTool) },

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -7,7 +7,7 @@ using Timberborn.ToolSystem;
 
 namespace ToolShortcuts
 {
-    [BepInPlugin("Timberborn.ToolShortcuts", "Tool Shortcuts", "0.3.1")]
+    [BepInPlugin("Timberborn.ToolShortcuts", "Tool Shortcuts", "0.3.2")]
     public class Plugin : BaseUnityPlugin
     {
         internal static ManualLogSource Log;

--- a/TimberbornToolShortcuts.csproj
+++ b/TimberbornToolShortcuts.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
+    <PackageReference Include="BepInEx.Core" Version="5.4.19.0" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
   </ItemGroup>
 

--- a/thunderstore/manifest.json
+++ b/thunderstore/manifest.json
@@ -1,9 +1,9 @@
 {
     "name": "ToolShortcuts",
-    "version_number": "0.3.1",
+    "version_number": "0.3.2",
     "website_url": "https://github.com/zallek/TimberbornToolShortcuts",
     "description": "Add key bindinds for the bottom tool bar",
     "dependencies": [
-        "BepInEx-BepInExPack_Timberborn-5.4.16"
+        "BepInEx-BepInExPack_Timberborn-5.4.19.0"
     ]
 }


### PR DESCRIPTION
In older versions the mod could not be loaded, because an interface of the game changed. This has been updated, now the mod loads again.

Additional, the BepInEx version has been changed to be the same that the official Timberborn-BepInEx-Mod has. Removed the wildcard '5*', because the dependencies in the manifest file had a constant version too.

Finally bumped the version to 3.2 as there was a change and the change should be released.